### PR TITLE
handle escaped single quote values in where

### DIFF
--- a/lib/active_record/sql_analyzer/configuration.rb
+++ b/lib/active_record/sql_analyzer/configuration.rb
@@ -150,7 +150,7 @@ module ActiveRecord
           Redactor.new(/\n/, " "),
           Redactor.new(/\s+/, " "),
           Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?-?\d+(\.\d+)?/, " = [REDACTED]"),
-          Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?x?'[^']*'/, " = '[REDACTED]'"),
+          Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?x?'.*?[^\\]'/, " = '[REDACTED]'"),
           Redactor.new(/VALUES \(.+\)$/, "VALUES ([REDACTED])"),
           Redactor.new(/IN \([^)]+\)/, "IN ([REDACTED])"),
           Redactor.new(/BETWEEN '[^']*' AND '[^']*'/, "BETWEEN '[REDACTED]' AND '[REDACTED]'"),

--- a/spec/active_record/sql_analyzer/redacted_logger_spec.rb
+++ b/spec/active_record/sql_analyzer/redacted_logger_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe ActiveRecord::SqlAnalyzer::RedactedLogger do
       end
     end
 
+    context "sql quoted" do
+      let(:event) do
+        {
+          caller: [""],
+          sql: "SELECT * FROM foo WHERE name = 'hello\\'s name'"
+        }
+      end
+
+      it "redacts" do
+        expect(filter_event[:sql]).to eq("SELECT * FROM foo WHERE name = '[REDACTED]'")
+      end
+    end
+
     context "sql" do
       let(:event) do
         {


### PR DESCRIPTION
`select * from {table} where name = 'escaped\'s name'` would only redact up the escaped
(i.e. `select * from {table} where name = '[REDACTED]'s name'`)
