### PR TITLE
Bugfix: do not log transactions with only nonmatching inserts/updates

### DIFF
--- a/lib/active_record/sql_analyzer/version.rb
+++ b/lib/active_record/sql_analyzer/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module SqlAnalyzer
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/active_record/sql_analyzer/end_to_end_spec.rb
+++ b/spec/active_record/sql_analyzer/end_to_end_spec.rb
@@ -241,6 +241,14 @@ RSpec.describe "End to End" do
     expect(log_def_hash.size).to eq(0)
   end
 
+  it "Does not log nonmatching-only insert transactions" do
+    transaction do
+      execute "INSERT INTO nonmatching_table (id) VALUES (1)"
+    end
+
+    expect(log_def_hash.size).to eq(0)
+  end
+
   context "Selectively sampling" do
     before do
       ActiveRecord::SqlAnalyzer.configure do |c|


### PR DESCRIPTION
Looks like the previous code didn't handle the case of only non-matching inserts in a transaction nicely
