### PR TITLE
Use print instead of puts for logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ gem "pry-byebug"
 gem "rake"
 
 group :test do
-  gem "mysql2", "~> 0.4", ">= 0.4.0"
+  gem "mysql2"
   gem "rspec", "~> 3.4"
-  gem "rubocop", "~> 0.30"
+  gem "rubocop", "0.58.2"
   gem "sql-parser", git: "https://github.com/nerdrew/sql-parser.git"
   gem "timecop", "~> 0.8"
 end

--- a/active_record-sql_analyzer.gemspec
+++ b/active_record-sql_analyzer.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 require File.expand_path('../lib/active_record/sql_analyzer/version', __FILE__)
 Gem::Specification.new do |s|
   s.authors       = ['Zachary Anker', 'Gabriel Gilder']
@@ -15,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.version       = ActiveRecord::SqlAnalyzer::VERSION
 
-  s.add_dependency 'activerecord', '~> 4.0', '>= 4.0.0'
+  s.add_dependency 'activerecord'
 
   s.add_development_dependency 'bundler', '~> 1.0'
 end

--- a/lib/active_record/sql_analyzer/backtrace_filter.rb
+++ b/lib/active_record/sql_analyzer/backtrace_filter.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       end
 
       def self.rails_root_regex
-        @rails_root ||= %r{^#{Regexp.escape(Rails.root.to_s)}}
+        @rails_root_regex ||= %r{^#{Regexp.escape(Rails.root.to_s)}}
       end
 
       def self.proc

--- a/lib/active_record/sql_analyzer/cli.rb
+++ b/lib/active_record/sql_analyzer/cli.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module SqlAnalyzer
     class CLI
-      attr_reader :options, :processor
+      attr_reader :options
 
       def initialize
         @options = {

--- a/lib/active_record/sql_analyzer/cli_processor.rb
+++ b/lib/active_record/sql_analyzer/cli_processor.rb
@@ -23,7 +23,6 @@ module ActiveRecord
         end
 
         local_data
-
       rescue => ex
         puts "#{ex.class}: #{ex.message}"
         puts ex.backtrace
@@ -73,7 +72,7 @@ module ActiveRecord
                 last_called, sha = line.split("|", 2)
                 last_called = Time.at(last_called.to_i).utc
 
-                local_usage[sha] ||= {"count" => 0}
+                local_usage[sha] ||= { "count" => 0 }
                 local_usage[sha]["count"] += 1
 
                 if !local_usage[sha]["last_called"] || local_usage[sha]["last_called"] < last_called

--- a/lib/active_record/sql_analyzer/compact_logger.rb
+++ b/lib/active_record/sql_analyzer/compact_logger.rb
@@ -13,13 +13,14 @@ module ActiveRecord
       end
 
       def log(event)
-        sha = Digest::MD5.hexdigest(event.to_s)
+        json = event.to_json
+        sha = json.hash
         unless logged_shas.include?(sha)
-          definition_log_file.puts("#{sha}|#{event.to_json}")
+          definition_log_file.print("#{sha}|#{json}\n")
           logged_shas << sha
         end
 
-        log_file.puts("#{Time.now.to_i}|#{sha}")
+        log_file.print("#{Time.now.to_i}|#{sha}\n")
       end
 
       def close

--- a/lib/active_record/sql_analyzer/configuration.rb
+++ b/lib/active_record/sql_analyzer/configuration.rb
@@ -152,16 +152,16 @@ module ActiveRecord
       end
 
       def setup_defaults
-        quotedValuePattern = %{('([^\\\\']|\\\\.|'')*'|"([^\\\\"]|\\\\.|"")*")}
+        quoted_value_pattern = %{('([^\\\\']|\\\\.|'')*'|"([^\\\\"]|\\\\.|"")*")}
         @options[:sql_redactors] = [
           Redactor.new(/\n/, " "),
           Redactor.new(/\s+/, " "),
           Redactor.new(/IN \([^)]+\)/i, "IN ('[REDACTED]')"),
           Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?-?\d+(\.\d+)?/i, " = '[REDACTED]'"),
-          Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?x?#{quotedValuePattern}/i, " = '[REDACTED]'"),
+          Redactor.new(/(\s|\b|`)(=|!=|>=|>|<=|<) ?(BINARY )?x?#{quoted_value_pattern}/i, " = '[REDACTED]'"),
           Redactor.new(/VALUES \(.+\)$/i, "VALUES ('[REDACTED]')"),
-          Redactor.new(/BETWEEN #{quotedValuePattern} AND #{quotedValuePattern}/i, "BETWEEN '[REDACTED]' AND '[REDACTED]'"),
-          Redactor.new(/LIKE #{quotedValuePattern}/i, "LIKE '[REDACTED]'"),
+          Redactor.new(/BETWEEN #{quoted_value_pattern} AND #{quoted_value_pattern}/i, "BETWEEN '[REDACTED]' AND '[REDACTED]'"),
+          Redactor.new(/LIKE #{quoted_value_pattern}/i, "LIKE '[REDACTED]'"),
           Redactor.new(/ LIMIT \d+/i, ""),
           Redactor.new(/ OFFSET \d+/i, ""),
           Redactor.new(/INSERT INTO (`?\w+`?) \([^)]+\)/i, "INSERT INTO \\1 (REDACTED_COLUMNS)"),

--- a/lib/active_record/sql_analyzer/monkeypatches/query.rb
+++ b/lib/active_record/sql_analyzer/monkeypatches/query.rb
@@ -31,7 +31,7 @@ module ActiveRecord
 
               if safe_sql =~ analyzer[:table_regex]
                 SqlAnalyzer.background_processor <<
-                _query_analyzer_private_query_stanza([query_analyzer_call], analyzer)
+                  _query_analyzer_private_query_stanza([query_analyzer_call], analyzer)
               end
             end
           end

--- a/lib/active_record/sql_analyzer/redacted_logger.rb
+++ b/lib/active_record/sql_analyzer/redacted_logger.rb
@@ -4,7 +4,7 @@ module ActiveRecord
       def filter_event(event)
         # Determine if we're doing extended tracing or only the first
         calls = event.delete(:calls).map do |call|
-          {sql: filter_sql(call[:sql]), caller: filter_caller(call[:caller])}
+          { sql: filter_sql(call[:sql]), caller: filter_caller(call[:caller]) }
         end
 
         # De-duplicate redacted calls to avoid many transactions with looping "N+1" queries.

--- a/spec/active_record/sql_analyzer/background_processor_spec.rb
+++ b/spec/active_record/sql_analyzer/background_processor_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ActiveRecord::SqlAnalyzer::BackgroundProcessor do
 
   let(:instance) { described_class.new }
 
-  let(:event) { {calls: [{caller: "CALLER", sql: "SQL"}], logger: logger} }
+  let(:event) { { calls: [{ caller: "CALLER", sql: "SQL" }], logger: logger } }
 
   let(:logger) do
     Class.new do
@@ -23,8 +23,8 @@ RSpec.describe ActiveRecord::SqlAnalyzer::BackgroundProcessor do
 
   before do
     ActiveRecord::SqlAnalyzer.configure do |c|
-      c.backtrace_filter_proc Proc.new { |lines| "BFP #{lines}" }
-      c.complex_sql_redactor_proc Proc.new { |sql| "CSRP #{sql}" }
+      c.backtrace_filter_proc(Proc.new { |lines| "BFP #{lines}" })
+      c.complex_sql_redactor_proc(Proc.new { |sql| "CSRP #{sql}" })
     end
   end
 

--- a/spec/active_record/sql_analyzer/cli_processor_spec.rb
+++ b/spec/active_record/sql_analyzer/cli_processor_spec.rb
@@ -29,20 +29,18 @@ RSpec.describe ActiveRecord::SqlAnalyzer::CLIProcessor do
 
   before do
     write_logs(:foo,
-      {sql: "F-SQL1", caller: "CALLER1", tag: true},
-      {sql: "F-SQL2", caller: "CALLER2", tag: true},
-      {sql: "F-SQL1", caller: "CALLER1", tag: true},
-      {sql: "F-SQL3", caller: "CALLER3", tag: true},
-      {sql: "F-SQL2", caller: "CALLER2", tag: true}
-    )
+               { sql: "F-SQL1", caller: "CALLER1", tag: true },
+               { sql: "F-SQL2", caller: "CALLER2", tag: true },
+               { sql: "F-SQL1", caller: "CALLER1", tag: true },
+               { sql: "F-SQL3", caller: "CALLER3", tag: true },
+               { sql: "F-SQL2", caller: "CALLER2", tag: true })
 
     write_logs(:bar,
-      {sql: "B-SQL1", caller: "CALLER1"},
-      {sql: "B-SQL2", caller: "CALLER2"},
-      {sql: "B-SQL3", caller: "CALLER3"},
-      {sql: "B-SQL2", caller: "CALLER2"},
-      {sql: "B-SQL1", caller: "CALLER1"}
-    )
+               { sql: "B-SQL1", caller: "CALLER1" },
+               { sql: "B-SQL2", caller: "CALLER2" },
+               { sql: "B-SQL3", caller: "CALLER3" },
+               { sql: "B-SQL2", caller: "CALLER2" },
+               { sql: "B-SQL1", caller: "CALLER1" })
   end
 
   subject(:process) do

--- a/spec/active_record/sql_analyzer/end_to_end_spec.rb
+++ b/spec/active_record/sql_analyzer/end_to_end_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "End to End" do
   before do
     ActiveRecord::SqlAnalyzer.configure do |c|
       c.logger_root_path tmp_dir
-      c.log_sample_proc Proc.new { |_name| true }
+      c.log_sample_proc(Proc.new { |_name| true })
 
       c.add_analyzer(
         name: :test_tag,
@@ -129,13 +129,15 @@ RSpec.describe "End to End" do
       "BEGIN; " \
       "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
       "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
-      "COMMIT;")
+      "COMMIT;"
+    )
 
     expect(log_def_hash[transaction_executed_twice_sha]["sql"]).to eq(
-     "BEGIN; " \
-     "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
-     "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
-     "COMMIT;")
+      "BEGIN; " \
+      "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
+      "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
+      "COMMIT;"
+    )
   end
 
   it "Logs nested transactions correctly" do
@@ -148,10 +150,11 @@ RSpec.describe "End to End" do
 
     transaction_executed_once_sha = log_reverse_hash[1]
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
-        "BEGIN; " \
-        "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
-        "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
-        "COMMIT;")
+      "BEGIN; " \
+      "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
+      "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
+      "COMMIT;"
+    )
   end
 
   it "Logs transactions with inserts correctly" do
@@ -162,10 +165,11 @@ RSpec.describe "End to End" do
 
     transaction_executed_once_sha = log_reverse_hash[1]
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
-          "BEGIN; " \
-            "INSERT INTO matching_table (REDACTED_COLUMNS) VALUES ('[REDACTED]'); " \
-            "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
-            "COMMIT;")
+      "BEGIN; " \
+        "INSERT INTO matching_table (REDACTED_COLUMNS) VALUES ('[REDACTED]'); " \
+        "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
+        "COMMIT;"
+    )
   end
 
   it "Logs mixed matching-nonmatching selects correctly" do
@@ -179,7 +183,8 @@ RSpec.describe "End to End" do
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
       "BEGIN; " \
       "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
-      "COMMIT;")
+      "COMMIT;"
+    )
   end
 
   it "Logs transaction with repeated selects correctly" do
@@ -193,10 +198,11 @@ RSpec.describe "End to End" do
     transaction_executed_once_sha = log_reverse_hash[1]
 
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
-                                                                    "BEGIN; " \
+      "BEGIN; " \
       "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
       "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; " \
-      "COMMIT;")
+      "COMMIT;"
+    )
   end
 
   it "Logs transaction with repeated inserts correctly" do
@@ -210,10 +216,11 @@ RSpec.describe "End to End" do
     transaction_executed_once_sha = log_reverse_hash[1]
 
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
-                                                                    "BEGIN; " \
+      "BEGIN; " \
       "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
       "INSERT INTO matching_table (REDACTED_COLUMNS) VALUES ('[REDACTED]'); " \
-      "COMMIT;")
+      "COMMIT;"
+    )
   end
 
   context "ActiveRecord generated transactions" do
@@ -240,10 +247,10 @@ RSpec.describe "End to End" do
       NonMatching.create
 
       expect(log_def_hash.map { |_hash, data| data["sql"] }).to match([
-        "INSERT INTO `matching_table` VALUES ()",
-        "BEGIN; INSERT INTO `matching_table` VALUES (); INSERT INTO `nonmatching_table` VALUES (); COMMIT;",
-        "SELECT `matching_table`.* FROM `matching_table` ORDER BY `matching_table`.`id` DESC"
-      ])
+                                                                        "INSERT INTO `matching_table` VALUES ()",
+                                                                        "BEGIN; INSERT INTO `matching_table` VALUES (); INSERT INTO `nonmatching_table` VALUES (); COMMIT;",
+                                                                        "SELECT `matching_table`.* FROM `matching_table` ORDER BY `matching_table`.`id` DESC"
+                                                                      ])
     end
   end
 
@@ -256,10 +263,11 @@ RSpec.describe "End to End" do
     transaction_executed_once_sha = log_reverse_hash[1]
 
     expect(log_def_hash[transaction_executed_once_sha]["sql"]).to eq(
-                                                                    "BEGIN; " \
+      "BEGIN; " \
       "SELECT * FROM matching_table WHERE id = '[REDACTED]'; " \
       "INSERT INTO nonmatching_table (REDACTED_COLUMNS) VALUES ('[REDACTED]'); " \
-      "COMMIT;")
+      "COMMIT;"
+    )
   end
 
   it "Does not log nonmatching-only queries" do
@@ -284,7 +292,7 @@ RSpec.describe "End to End" do
       ActiveRecord::SqlAnalyzer.configure do |c|
         times_called = 0
         # Return true every other call, starting with the first call
-        c.log_sample_proc Proc.new { |_name| (times_called += 1) % 2 == 1 }
+        c.log_sample_proc(Proc.new { |_name| (times_called += 1) % 2 == 1 })
       end
     end
 
@@ -294,7 +302,8 @@ RSpec.describe "End to End" do
 
       expect(log_def_hash.size).to eq(1)
       expect(log_def_hash.map { |_hash, query| query['sql'] }).to eq([
-        "SELECT * FROM matching_table WHERE id = '[REDACTED]'"])
+                                                                       "SELECT * FROM matching_table WHERE id = '[REDACTED]'"
+                                                                     ])
     end
 
     it "Samples some but not other whole transactions" do
@@ -309,20 +318,20 @@ RSpec.describe "End to End" do
       end
 
       expect(log_def_hash.map { |_hash, data| data["sql"] }).to match([
-        "SELECT * FROM matching_table WHERE id = '[REDACTED]'",
-        "BEGIN; "\
-        "SELECT * FROM matching_table WHERE id = '[REDACTED]'; "\
-        "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; "\
-        "COMMIT;",
-        "SELECT * FROM matching_table WHERE id = '[REDACTED]' and id = '[REDACTED]'"
-      ])
+                                                                        "SELECT * FROM matching_table WHERE id = '[REDACTED]'",
+                                                                        "BEGIN; "\
+                                                                        "SELECT * FROM matching_table WHERE id = '[REDACTED]'; "\
+                                                                        "SELECT * FROM matching_table WHERE test_string = '[REDACTED]'; "\
+                                                                        "COMMIT;",
+                                                                        "SELECT * FROM matching_table WHERE id = '[REDACTED]' and id = '[REDACTED]'"
+                                                                      ])
     end
   end
 
   context "when sampling is disabled" do
     before do
       ActiveRecord::SqlAnalyzer.configure do |c|
-        c.log_sample_proc Proc.new { |_name| false }
+        c.log_sample_proc(Proc.new { |_name| false })
       end
     end
 

--- a/spec/active_record/sql_analyzer/redacted_logger_spec.rb
+++ b/spec/active_record/sql_analyzer/redacted_logger_spec.rb
@@ -267,9 +267,9 @@ RSpec.describe ActiveRecord::SqlAnalyzer::RedactedLogger do
       let(:event) do
         {
           calls: [{
-                    caller: [],
-                    sql: "INSERT INTO `boom` (`bam`, `foo`) VALUES ('howdy', 'dowdy')",
-                  }]
+            caller: [],
+            sql: "INSERT INTO `boom` (`bam`, `foo`) VALUES ('howdy', 'dowdy')",
+          }]
         }
       end
 

--- a/spec/support/db_connection.rb
+++ b/spec/support/db_connection.rb
@@ -19,7 +19,6 @@ class DBConnection
   end
 
   def self.setup_db
-    ActiveRecord::Base.raise_in_transactional_callbacks = true
     conn = ActiveRecord::Base.establish_connection(configuration)
     conn.connection.execute <<-SQL
       CREATE DATABASE IF NOT EXISTS ar_sql_analyzer_test


### PR DESCRIPTION
I observed some instances of a single line receiving two sha/event
pairs, which broke JSON parsing. One possible explanation for this is
that internally puts uses two system calls - one to write the argument,
and one to write the newline - and it seems possible that if multiple
processses are writing to the same log, you could see issues like this.
Writing both the message and the newline in the same call should prevent
this issue.