### PR TITLE
Support activerecord 6, activerecord 7, and Ruby 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0 / 2024-02-12
+Support activerecord 6, activerecord 7, and ruby 3
+
 ## 0.3.0 / 2018-08-31
 Breaking Changes
 - Change hash method: use `json.hash` instead of `MD5.hexdigest(json)`.

--- a/active_record-sql_analyzer.gemspec
+++ b/active_record-sql_analyzer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord'
 
-  s.add_development_dependency 'bundler', '~> 1.0'
+  s.add_development_dependency 'bundler', '~> 2.0'
 end

--- a/lib/active_record/sql_analyzer/monkeypatches/query.rb
+++ b/lib/active_record/sql_analyzer/monkeypatches/query.rb
@@ -11,8 +11,8 @@ module ActiveRecord
         else
           :execute
         end
-        define_method(execute_method) do |sql, *args|
-          return super(sql, args) unless SqlAnalyzer.config
+        define_method(execute_method) do |sql, *args, **kwargs|
+          return super(sql, *args, **kwargs) unless SqlAnalyzer.config
           safe_sql = nil
           query_analyzer_call = nil
 
@@ -20,7 +20,7 @@ module ActiveRecord
           # deferred until just before query execution, and so
           # begin_db_transaction is now called inside the `super` call here.
           begin
-            super(sql, args)
+            super(sql, *args, **kwargs)
           ensure
             # Record "full" transactions (see below for more information about "full")
             if @_query_analyzer_private_in_transaction

--- a/lib/active_record/sql_analyzer/monkeypatches/query.rb
+++ b/lib/active_record/sql_analyzer/monkeypatches/query.rb
@@ -6,37 +6,47 @@ module ActiveRecord
       module Query
         QueryAnalyzerCall = Struct.new(:sql, :caller)
 
-        def execute(sql, *args)
-          return super unless SqlAnalyzer.config
+        execute_method = if ActiveRecord.version >= Gem::Version.new('7.0')
+          :raw_execute
+        else
+          :execute
+        end
+        define_method(execute_method) do |sql, *args|
+          return super(sql, args) unless SqlAnalyzer.config
           safe_sql = nil
           query_analyzer_call = nil
 
-          # Record "full" transactions (see below for more information about "full")
-          if @_query_analyzer_private_in_transaction
-            if @_query_analyzer_private_record_transaction
-              safe_sql ||= sql.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-              query_analyzer_call ||= QueryAnalyzerCall.new(safe_sql, caller)
-              @_query_analyzer_private_transaction_queue << query_analyzer_call
+          # Starting with activerecord v6, transaction materialization is
+          # deferred until just before query execution, and so
+          # begin_db_transaction is now called inside the `super` call here.
+          begin
+            super(sql, args)
+          ensure
+            # Record "full" transactions (see below for more information about "full")
+            if @_query_analyzer_private_in_transaction
+              if @_query_analyzer_private_record_transaction
+                safe_sql ||= sql.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+                query_analyzer_call ||= QueryAnalyzerCall.new(safe_sql, caller)
+                @_query_analyzer_private_transaction_queue << query_analyzer_call
+              end
             end
-          end
 
-          # Record interesting queries
-          SqlAnalyzer.config[:analyzers].each do |analyzer|
-            if SqlAnalyzer.config[:should_log_sample_proc].call(analyzer[:name])
-              # This is here rather than above intentionally.
-              # We assume we're not going to be analyzing 100% of queries and want to only re-encode
-              # when it's actually relevant.
-              safe_sql ||= sql.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
-              query_analyzer_call ||= QueryAnalyzerCall.new(safe_sql, caller)
+            # Record interesting queries
+            SqlAnalyzer.config[:analyzers].each do |analyzer|
+              if SqlAnalyzer.config[:should_log_sample_proc].call(analyzer[:name])
+                # This is here rather than above intentionally.
+                # We assume we're not going to be analyzing 100% of queries and want to only re-encode
+                # when it's actually relevant.
+                safe_sql ||= sql.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+                query_analyzer_call ||= QueryAnalyzerCall.new(safe_sql, caller)
 
-              if safe_sql =~ analyzer[:table_regex]
-                SqlAnalyzer.background_processor <<
-                  _query_analyzer_private_query_stanza([query_analyzer_call], analyzer)
+                if safe_sql =~ analyzer[:table_regex]
+                  SqlAnalyzer.background_processor <<
+                    _query_analyzer_private_query_stanza([query_analyzer_call], analyzer)
+                end
               end
             end
           end
-
-          super
         end
 
         def begin_db_transaction

--- a/lib/active_record/sql_analyzer/monkeypatches/tagger.rb
+++ b/lib/active_record/sql_analyzer/monkeypatches/tagger.rb
@@ -2,7 +2,7 @@ module ActiveRecord
   module SqlAnalyzer
     module Monkeypatches
       module Tagger
-        def initialize(*)
+        def initialize(*, **)
           super
           @_ar_analyzer_tag = nil
         end

--- a/lib/active_record/sql_analyzer/version.rb
+++ b/lib/active_record/sql_analyzer/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module SqlAnalyzer
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end


### PR DESCRIPTION
Starting with activerecord 6, transaction materialization is deferred
until query execution, so reorder our `execute` monkeypatch to run the
query and then log it.

Starting with activerecord 7, the "real work" method is now named
`raw_execute`, so patch that one when that version is detected instead.

Starting with Ruby 3, kwargs need explicit delegation.

Tested on every combination of Ruby (2.7.8p225, 3.0.6p216, 3.1.4p223, 3.2.2) and
activerecord (5.2.8.1, 6.0.6.1, 7.1.3). activerecord 5.2.8.1 does not support Ruby 3.